### PR TITLE
ci: test with `1`, `lts` and `pre` versions of julia

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -21,6 +21,7 @@ jobs:
         version:
           - "1"
           - "lts"
+          - "pre"
         os:
           - "ubuntu-latest"
           - "macos-latest"


### PR DESCRIPTION
Test the package with Julia v1, the lts version and latest pre-release