### PR TITLE
Widen DiffEqBase compat to allow v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 [compat]
 Compat = "4.1"
 DASKR_jll = "1"
-DiffEqBase = "6.217"
+DiffEqBase = "6.217, 7"
 PrecompileTools = "1.2"
 Reexport = "1.0"
 SciMLBase = "2.119, 3.1"


### PR DESCRIPTION
## Summary

PR #90 (the v2 → v3 major bump) was version-only and inherited the prior `DiffEqBase = "6.217"` compat cap without widening it for v7. This makes DASKR v3 unresolvable alongside the v7 DiffEqBase / SciMLBase v3 ecosystem.

This PR applies the same fix already applied to other SciML packages:
- IRKGaussLegendre #114
- MethodOfLines #553
- ModelingToolkitStandardLibrary #445

**Change:** `DiffEqBase = "6.217"` → `DiffEqBase = "6.217, 7"`

No source changes — pure compat widening, no version bump.

### Local resolution snapshot (Julia 1.10, `Pkg.instantiate()`)

```
DiffEqBase => 7.0.0
SciMLBase   => 3.6.0
DASKR       precompiled successfully
```