### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,21 +11,9 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+  downgrade:
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary
Converts the remaining inline CI workflows to the centralized SciML reusable workflows, pinned at `@v1`, each with `secrets: "inherit"`. Tests were already on the central caller.

### Converted (inline -> central)
- **FormatCheck.yml** (Runic): `fredrikekre/runic-action@v1` inline -> `runic.yml@v1`
- **SpellCheck.yml** (typos): `crate-ci/typos@v1.18.0` inline -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1` (preserves `julia-version: 1.10`, `skip: Pkg,TOML`, and the default `allow-reresolve: false` matching the original `ALLOW_RERESOLVE: false`)

### Unchanged
- **Tests.yml**: already used `tests.yml@v1` (tests/nopre/mtk jobs) with `secrets: "inherit"`. Left as-is, matrices preserved exactly.
- **TagBot.yml**: unchanged.

### Other
- **dependabot.yml**: removed the now-unnecessary `crate-ci/typos` version ignore from the `github-actions` block; preserved `github-actions` (`/`, weekly) and `julia` (`/` + `/test`, daily, group all-julia-packages `*`) blocks.
- No `docs/` directory, so no Documentation caller added.
- No CompatHelper workflow present (nothing to delete).

### Checks
- Runic: ran `Runic.main(["--inplace","."])` locally - no formatting changes (repo was already Runic-clean).
- Typos: ran `typos -w .` then `typos .` (exit 0) - 0 typos fixed; existing `.typos.toml` preserved.
- All changed YAML validated with `yaml.safe_load`.

### Note on branch protection
Job/check names change with the move to reusable workflows (e.g. the Runic check now runs under the reusable workflow). Any branch-protection required-status-check names will need updating to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)