### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,6 +14,5 @@ jobs:
   downgrade:
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
+      julia-version: "lts"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR applies the canonical SciML CI cleanup:

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot` job (permissions + steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1`.
- **Downgrade caller**: removed the hand-listed `skip: "Pkg,TOML"` input (both are Julia stdlibs and are now auto-populated by the centralized downgrade workflow); set `julia-version` to `"lts"`.

Not a monorepo (no `lib/` subpackages), so no TagBot subpackage matrix.

Ignore until reviewed by @ChrisRackauckas.