### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,53 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
-    secrets: "inherit"
-
-  nopre:
-    name: "NoPre"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-        os:
-          - "ubuntu-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
-      group: "NoPre"
-    secrets: "inherit"
-
-  mtk:
-    name: "MTK"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-        os:
-          - "ubuntu-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
-      group: "MTK"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,9 @@
+[All]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+[NoPre]
+versions = ["1", "lts"]
+
+[MTK]
+versions = ["1"]


### PR DESCRIPTION
## Summary

Convert the root `Tests.yml` workflow into the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the group × version (× os) matrix declared once in a **root** `test/test_groups.toml`.

The workflow filename (`Tests.yml`) and `name:` (`Tests`), plus the `on:` triggers and `concurrency:` block, are all preserved verbatim so branch-protection status checks keep matching. All other workflow files are left untouched.

## Group mapping (Category A — runtests.jl already dispatches on GROUP)

The previous `Tests.yml` hand-maintained three matrix jobs (`tests`/`nopre`/`mtk`) over `tests.yml@v1`. These map 1:1 to root test groups in `test/test_groups.toml`:

```toml
[All]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]

[NoPre]
versions = ["1", "lts"]

[MTK]
versions = ["1"]
```

- `[All]` — the default suite. The old default job passed **no** `group`, i.e. `GROUP=""`. `runtests.jl` does `GROUP = get(ENV, "GROUP", "All")` and only branches on `"NoPre"`/`"MTK"`, so `GROUP=""` and `GROUP="All"` are behaviorally identical: both run exactly the main suite. Using the documented default `"All"` here preserves that behavior.
- `[NoPre]` — JET static analysis (`test/nopre/jet.jl`), ubuntu only, `1`+`lts` (matches the old `nopre` job; JET is additionally guarded on `isempty(VERSION.prerelease)` in runtests.jl).
- `[MTK]` — ModelingToolkit integration (`test/mtk/initialization.jl`), ubuntu only, `1` (matches the old `mtk` job).

No `with:` inputs are required: the old jobs used only defaults (check-bounds `yes`, coverage on, `src,ext` coverage dirs, `GROUP` env var, no apt packages), which all match `grouped-tests.yml@v1` defaults. No `runtests.jl` change is needed.

## Matrix-match verification

Ran `scripts/compute_affected_sublibraries.jl <repo> --root-matrix` (SciML/.github @ v1) against the new `test/test_groups.toml`. It emits 12 (group, version, runner) cells:

- All: `{1,lts,pre} × {ubuntu,macos,windows}` = 9
- NoPre: `{1,lts} × ubuntu` = 2
- MTK: `{1} × ubuntu` = 1

This reproduces the OLD workflow's matrix **12/12 exact** (9 + 2 + 1). The only difference is the default suite's `GROUP` env value changes from `""` to `"All"`, which is behaviorally identical as noted above.

TOML and YAML both parse cleanly (static-verified).

## QA

Category A repo — the `NoPre` group already runs JET static analysis, so no new local QA run was required. No test was skipped, broadened, or silenced. No source bugs uncovered; no exclusions added.

---

Ignore until reviewed by @ChrisRackauckas.