### PR TITLE
Bump version to 3.1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASKR"
 uuid = "165a45c3-f624-5814-8e85-3bdf39a7becd"
-version = "3.1.2"
+version = "3.1.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Automated patch version bump (3.1.2 -> 3.1.3) to release unreleased commits on `master` via JuliaRegistrator.