### PR TITLE
Drop QA self source path

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -5,9 +5,6 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-DASKR = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Remove the test/qa `[sources]` self-path entry now that SciMLTesting 2.1 handles package-under-test resolution.

## Validation
- `git diff --check`
- `~/.juliaup/bin/julia +release --startup-file=no -e 'using TOML; TOML.parsefile("Project.toml"); TOML.parsefile("test/qa/Project.toml")'`\n- `GROUP=QA timeout 3600 ~/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.test(; coverage=false)'`