### PR TITLE
Release prep: bump DASKR to 3.1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASKR"
 uuid = "165a45c3-f624-5814-8e85-3bdf39a7becd"
-version = "3.1.3"
+version = "3.1.4"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Patch release bumping version 3.1.3 -> 3.1.4 to register the accumulated docstring/QA/test-scaffolding changes (test-only SciMLTesting compat update, QA source path cleanup) since the last release. No functional/source changes.