### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,10 +1,7 @@
 using SciMLTesting, DASKR, Test
 using JET
 
-diffeqbase_reexports = Tuple(names(DASKR.DiffEqBase))
-
 run_qa(
     DASKR;
-    api_docs_kwargs = (; rendered = true, rendered_ignore = diffeqbase_reexports),
     explicit_imports = true,
 )


### PR DESCRIPTION
Remove DASKR-specific public API documentation QA ignores and use the standard SciMLTesting check.

Validation:
- Runic 1.7 with docstrings
- `GROUP=QA Pkg.test()`
- `Pkg.test()`

Ignore until reviewed by @ChrisRackauckas.