### PR TITLE
Bump DASKR to v3.1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASKR"
 uuid = "165a45c3-f624-5814-8e85-3bdf39a7becd"
-version = "3.1.4"
+version = "3.1.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Bumps `DASKR` **v3.1.4 → v3.1.5** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Use SciMLTesting 2.4 strict QA (#112) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)