### PR TITLE
Bump version to 3.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DASKR"
 uuid = "165a45c3-f624-5814-8e85-3bdf39a7becd"
-version = "3.1.5"
+version = "3.2.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## What changed and why

Bumps DASKR from 3.1.5 to 3.2.0 to release the restored, explicitly documented SciML common interface from https://github.com/SciML/DASKR.jl/pull/116. This is the next consecutive version and follows the minor-bump policy for restored public API in a package at version 1 or later.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

- `~/.juliaup/bin/julia +release -m Runic --check .` — exited 0.
- `typos Project.toml` — exited 0 with no findings.
- `GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `QA | 67 passed / 67 total`; `Testing DASKR tests passed`.
- `~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'` — `Common interface | 16 passed / 16 total`; `Testing DASKR tests passed`. The raw-interface testset contains zero assertions and completed normally.

## Not verified

The docs build and downstream/allowed-to-fail jobs were not run locally because this PR changes only the package version.

AI continuation: OpenAI Codex session ID 01a03a11-47c2-77e0-858b-167004f0b79c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ